### PR TITLE
Deploy with Github Packages

### DIFF
--- a/.github/workflows/DeployOnRelease.yml
+++ b/.github/workflows/DeployOnRelease.yml
@@ -1,0 +1,23 @@
+on:
+ release:
+   types: [created]
+
+jobs:
+ release:
+   runs-on: macos-latest
+   steps:
+     - name: Checkout code
+       uses: actions/checkout@v2
+
+     - name: Setup Java
+       uses: actions/setup-java@v1
+       with:
+           java-version: 11
+     - name: Publish
+       run: |
+           cd ${GITHUB_WORKSPACE}
+           chmod +x ./gradlew
+           ./gradlew check publish --no-configure-on-demand --no-daemon
+       env:
+           ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
+           ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}

--- a/kmqtt-broker/build.gradle.kts
+++ b/kmqtt-broker/build.gradle.kts
@@ -130,12 +130,10 @@ tasks {
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
+            name = "github"
             url = uri("https://maven.pkg.github.com/davidepianca98/KMQTT")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_USERNAME")
-                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_PACKAGES")
-            }
+            credentials(PasswordCredentials::class)
+
         }
     }
 }

--- a/kmqtt-client/build.gradle.kts
+++ b/kmqtt-client/build.gradle.kts
@@ -1,13 +1,12 @@
-
 plugins {
     kotlin("multiplatform")
     id("maven-publish")
     id("kotlinx-atomicfu")
 }
 
+
 kotlin {
     explicitApi()
-
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
@@ -118,12 +117,10 @@ kotlin {
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
+            name = "github"
             url = uri("https://maven.pkg.github.com/davidepianca98/KMQTT")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_USERNAME")
-                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_PACKAGES")
-            }
+            credentials(PasswordCredentials::class)
         }
     }
 }
+

--- a/kmqtt-common/build.gradle.kts
+++ b/kmqtt-common/build.gradle.kts
@@ -162,3 +162,13 @@ kotlin {
         }
     }
 }
+
+publishing {
+    repositories {
+        maven {
+            name = "github"
+            url = uri("https://maven.pkg.github.com/davidepianca98/KMQTT")
+            credentials(PasswordCredentials::class)
+        }
+    }
+}


### PR DESCRIPTION
Hi, we are using Github Packages to deploy KMM libraries in order to have also the iOS targets deployed. We've added a workflow to deploy all the targets when a new TAG is created. 
The final result would be something like this https://github.com/orgs/Nextome/packages?repo_name=KMQTT