### PR TITLE
Add runAsync() to MQTTClient to workaround infinite loop bug on Client

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 kotlin.code.style=official
 serializationVersion=1.6.2
-coroutineVersion=1.8.0-RC
 atomicfuVersion=0.23.1
 nodeWrapperVersion=18.16.12-pre.683
 kotlin.js.generate.executable.default=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,8 @@
+[versions]
+coroutines = "1.8.0"
+
+[libraries]
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+[plugins]

--- a/kmqtt-broker/build.gradle.kts
+++ b/kmqtt-broker/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 }
 
 val serializationVersion: String by project
-val coroutineVersion: String by project
 val atomicfuVersion: String by project
 val nodeWrapperVersion: String by project
 
@@ -67,7 +66,7 @@ kotlin {
                 implementation(project(":kmqtt-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:$serializationVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
+                implementation(libs.kotlinx.coroutines.core)
             }
         }
         val commonTest by getting {
@@ -75,7 +74,7 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(project(":kmqtt-client"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion")
+                implementation(libs.kotlinx.coroutines.test)
                 implementation("com.goncalossilva:resources:0.4.0")
             }
         }

--- a/kmqtt-common/build.gradle.kts
+++ b/kmqtt-common/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
+                api(libs.kotlinx.coroutines.core)
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
Hi! I'm taking the liberty of proposing the solution discussed in issues #21 and #40 that tries to solve the problem

I hope you find it usefull.

### Description of the problem
When `MQTTClient.run()` is executed, the thread gets saturated and all messages are delayed until lock gets freed up.  

**MQTTClient.kt**
```
     public fun run() {
        while (running) {
            step()
        }
    }

     public fun step() {
        lock.withLock {      // <- ReentrantLock is not acquiring the lock resulting on a infinite loop with no room for other concurrent tasks on this thread 
            if (running) {
                connectSocket()
                check()
            }
        }
    }
```

### Proposed solution
Since coroutines are already added to the project
1. Make coroutines available into client as well. 
1. Create a new function `public fun runAsync(...)` to avoid breaking changes

### Extra 
I have done some small extra changes, if you don't feel is the way or moment to apply them I will undo, no problem for that :)

1. Add support for the new dependencies management standard that eases up version management.
1. Bump coroutines version from release candidate to stable version