### PR TITLE
Add handling for received websocket ping in mqtt-client

### DIFF
--- a/kmqtt-client/src/commonMain/kotlin/WebSocket.kt
+++ b/kmqtt-client/src/commonMain/kotlin/WebSocket.kt
@@ -130,6 +130,11 @@ public class WebSocket(private val socket: SocketInterface, host: String, path: 
         return null
     }
 
+    private fun decodePing(length: ULong): UByteArray? {
+        send(decodeBinary(length), 0xA)
+        return null
+    }
+
     private fun decodePong(length: ULong): UByteArray? {
         decodeBinary(length)
         return null
@@ -156,6 +161,7 @@ public class WebSocket(private val socket: SocketInterface, host: String, path: 
                 val decoded = when (opcode.toInt()) {
                     0x2 -> decodeBinary(length)
                     0x8 -> decodeClose(length)
+                    0x9 -> decodePing(length)
                     0xA -> decodePong(length)
                     else -> {
                         close()


### PR DESCRIPTION
I’ve added handling for server-sent WebSocket Ping (0x9) frames in the MQTT client. The issue was that the client would throw an exception when a Ping was received due to the lack of proper handling. With this change, the client now correctly responds with a Pong message. Thank you for maintaining this library!