### PR TITLE
Fix disconnect type error when server responds mqtt_qos_error

### DIFF
--- a/kmqtt-client/src/commonMain/kotlin/io/github/davidepianca98/MQTTClient.kt
+++ b/kmqtt-client/src/commonMain/kotlin/io/github/davidepianca98/MQTTClient.kt
@@ -403,7 +403,12 @@ public class MQTTClient(
                 }
             } catch (e: MQTTException) {
                 lastException = e
-                disconnect(e.reasonCode)
+                disconnect(
+                    when (e.reasonCode) {
+                        ReasonCode.GRANTED_QOS1, ReasonCode.GRANTED_QOS2 -> ReasonCode.SUCCESS
+                        else -> e.reasonCode
+                    }
+                )
                 close()
                 onDisconnected(null)
                 throw e


### PR DESCRIPTION
When the server responds with ReasonCode.GRANTED_QOS1 or ReasonCode.GRANTED_QOS2 MQTTClien throws IllegalArgumentException("Invalid reason code")