### PR TITLE
Broker - WS read and write all bytes at once when decoding

### DIFF
--- a/kmqtt-broker/src/commonMain/kotlin/io/github/davidepianca98/socket/tcp/WebSocket.kt
+++ b/kmqtt-broker/src/commonMain/kotlin/io/github/davidepianca98/socket/tcp/WebSocket.kt
@@ -85,9 +85,12 @@ internal class WebSocket(private val socket: Socket) : SocketInterface {
 
     private fun decodeBinary(length: ULong, key: UByteArray): UByteArray {
         val decoded = ByteArrayOutputStream()
-        for (i in 0 until length.toInt()) {
-            decoded.write(currentReceivedData.read() xor key[i and 0x3])
+
+        val bytes = currentReceivedData.readBytes(length.toInt()).mapIndexed { index, uByte ->
+            uByte xor key[index and 0x3]
         }
+        decoded.write(bytes.toUByteArray())
+
         currentReceivedData.shift()
         return decoded.toByteArray()
     }


### PR DESCRIPTION
Drastically improves performance when publishing large payloads and reduces memory usage.
Note that there is still a memory spike, just to a lower degree.

Partially resolves https://github.com/davidepianca98/KMQTT/issues/79

Before:
![image](https://github.com/user-attachments/assets/67ecdcba-1450-4f58-9468-f82b712a60ec)
After:
![image](https://github.com/user-attachments/assets/bf79b020-f845-4638-bc2a-36b816534338)